### PR TITLE
Dolphin brain sulci removal

### DIFF
--- a/BRAINMAPPERS.md
+++ b/BRAINMAPPERS.md
@@ -23,3 +23,9 @@ Slice numbers:      axial 112
 Length:             mm  
 Volume:             509491 mm3  
 
+Name:               **faruk**  
+GitHub:             @ofgulban  
+Species:            Bottlenose dolphin  
+Slice numbers:      all ?  
+Length:             ?? mm  
+Volume:             ?? mm3


### PR DESCRIPTION
I don't know what to put to slice numbers length and volume because of using a [tool](https://github.com/ofgulban/segmentator) removing most of the sulci across many slices.

I have worked on the dolphin brain source image and merged the latest brainbox segmentation as the last step to incorporate the slices done so far (to see what I have done: [link](https://github.com/ofgulban/segmentator/wiki/Case-V%3A-Bottlenose-dolphin-brain)).